### PR TITLE
load as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Using the regular Node interpreter:
 ```bash
 # execute literate Markdown files with Node,
 # loading lit-node module from command line
-$ node --require lit-node ./test.md
+$ node --require lit-node/register ./test.md
 ```
 
 Alternately, the same thing using the Node alias that automatically loads the lit-node module:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lit-node
 
-Self-documenting Node scripts through literate programming. Based on [lit](https://github.com/vijithassar/lit) by [Vijith Assar](https://twitter.com/vijithassar).
+Load Markdown files as Node modules and run the code blocks. Self-documenting Node scripts through literate programming! Based on [lit](https://github.com/vijithassar/lit) by [Vijith Assar](https://twitter.com/vijithassar).
 
 ## Overview
 
@@ -10,17 +10,28 @@ Self-documenting Node scripts through literate programming. Based on [lit](https
 
 ```bash
 # install
-$ npm install --global lit-node
+$ npm install lit-node
 
-# lit-node is just node with direct
+# load module from command line to enable
+# execution of literate Markdown with Node
+$ node --require lit-node program.md
+
+# lit-node alias is just node with direct
 # support for importing modules from
 # Markdown code blocks
-$ lit-node
+$ lit-node program.md
 ```
 
 ## Instructions
 
-First, install `lit-node`; a global install is probably most useful:
+First, install `lit-node`.
+
+```bash
+# install
+$ npm install lit-node
+```
+
+You'll probably want a **global** install if you intend to use either the REPL or the alias for Node which automatically loads the lit-node module (more on these in a moment):
 
 ```bash
 # install
@@ -49,7 +60,19 @@ console.log('hello world');
 
 Now you can **execute your Markdown file**!
 
+Using the regular Node interpreter:
+
 ```bash
+# execute literate Markdown files with Node,
+# loading lit-node module from command line
+$ node --require lit-node ./test.md
+```
+
+Alternately, the same thing using the Node alias that automatically loads the lit-node module:
+
+```bash
+# execute literate Markdown files with Node alias;
+# lit-node module is automatically loaded
 $ lit-node ./test.md
 ```
 
@@ -59,28 +82,31 @@ You *must* include `js` or `javascript` as a language specifier after opening up
 
 ### require()
 
-From within a script being executed by `lit-node`, you can `require()` other Markdown files, which will be parsed and executed just like any other module. The `.md` file extension is optional.
-
-~~~
-
-You can do this within test.md:
+Any script that has previously loaded `lit-node` with `require()` can then `require()` other Markdown files, which will be parsed and executed just like any other module. The `.md` file extension is optional, but recommended.
 
 ```javascript
-// import module from a Markdown file
-const thing = require('./thing.md');
+# load lit-node module
+require('lit-node')
 
-// log the type of whatever was exported
-console.log(typeof thing);
+# scripts can load code from literate Markdown files
+const thing = require('thing.md')
+console.log(typeof thing)
 ```
+
 ~~~
 
 ### REPL
 
-Assuming you've installed globally as mentioned above, you can also launch an interactive [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) which will support Markdown imports.
+Assuming you've installed globally as mentioned above, you can also use the Node alias installed by lit-node to launch an interactive [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) which will support Markdown imports.
 
 ```bash
+# launch Node alias REPL with 
+# lit-node module already loaded
 $ lit-node
-> const thing = require('./thing.md'); // import module from a Markdown file
+
+# the REPL can load code from literate Markdown files
+> const thing = require('./thing.md');
+> typeof thing
 ```
 
 ### Top Level Await

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Any script that has previously loaded `lit-node` with `require()` can then `requ
 
 ```javascript
 # load lit-node module
-require('lit-node')
+require('lit-node/register.js')
 
 # scripts can load code from literate Markdown files
 const thing = require('thing.md')

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ $ npm install lit-node
 
 # load module from command line to enable
 # execution of literate Markdown with Node
-$ node --require lit-node program.md
+$ node --require lit-node/register program.md
 
 # lit-node alias is just node with direct
 # support for importing modules from

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+require('./register.js')

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require('./register.js')
+module.exports = require('./compile.js');

--- a/package.json
+++ b/package.json
@@ -3,11 +3,14 @@
   "description": "Self-documenting Node scripts through literate programming",
   "version": "0.0.1",
   "license": "LIL",
+  "main": "index.js",
   "bin": {
     "lit-node": "lit-node"
   },
   "scripts": {
-    "test": "./lit-node test/test.md"
+    "test-path": "./lit-node test/test.md",
+    "test-module": "node --require . test/test.md",
+    "test": "npm run test-path && npm run test-module"
   },
   "devDependencies": {
     "chalk": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test-path": "./lit-node test/test.md",
-    "test-module": "node --require . test/test.md",
+    "test-module": "node --require ./register.js test/test.md",
     "test": "npm run test-path && npm run test-module"
   },
   "devDependencies": {


### PR DESCRIPTION
Adds support for loading lit-node as a module instead of requiring the special interpreter or REPL. This in turn allows use of lit-node via standard Node commands, which removes a substantial barrier to adoption and improves interoperability with other tools in the Node ecosystem.

Before this change:

```bash
# run literate code with special Node.js interpreter
$ lit-node program.md
```

After this change:

```bash
# run literate code with regular Node.js interpreter
$ node --require lit-node program.md
```

This is a vastly more cooperative command line interface. It will be much more familiar to developers, works seamlessly with many more Node projects, allows further Node customizations, and also works with other programs which are lightweight wrappers around Node.