### PR TITLE
remove top level await

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,6 @@ $ lit-node
 > typeof thing
 ```
 
-### Top Level Await
-
-Top-level use of `await` is [generally a bad idea](https://gist.github.com/Rich-Harris/0b6f317657f5167663b493c722647221), but allowed in this case because it can be useful for short scripts.
-
-~~~
-```javascript
-const request = require('request-promise');
-console.log(await request('https://example.com'));
-```
-~~~
 
 ## Other Tools
 

--- a/compile.js
+++ b/compile.js
@@ -21,7 +21,7 @@ function compile(markdown) {
 		});
 
 	// output an async function
-	return '(async () => {' + code.join('') + '})();';
+	return code.join('');
 
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "lit-node",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -10,7 +10,7 @@
 			"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
 			"dev": true,
 			"requires": {
-				"color-convert": "1.9.1"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"chalk": {
@@ -19,9 +19,9 @@
 			"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.0",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "4.5.0"
+				"ansi-styles": "^3.1.0",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^4.0.0"
 			}
 		},
 		"color-convert": {
@@ -30,7 +30,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"color-name": "^1.1.1"
 			}
 		},
 		"color-name": {
@@ -57,7 +57,7 @@
 			"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
 			"dev": true,
 			"requires": {
-				"has-flag": "2.0.0"
+				"has-flag": "^2.0.0"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lit-node",
   "description": "Self-documenting Node scripts through literate programming",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "license": "LIL",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test-path": "./lit-node test/test.md",
     "test-module": "node --require ./register.js test/test.md",
-    "test": "npm run test-path && npm run test-module"
+    "test": "npm run test-path && npm run test-module",
+    "prepublishOnly": "npm run test"
   },
   "devDependencies": {
     "chalk": "^2.3.0"

--- a/test/test.md
+++ b/test/test.md
@@ -64,14 +64,6 @@ assert.equal(problems, 99);
 success('imports a `.md` file without specifying the extension');
 ```
 
-When running scripts, it's really useful to be able to use `async`/`await`. lit-node wraps everything in an async IIFE to make that possible:
-
-```js
-const value = await Promise.resolve('delayed');
-assert.equal(value, 'delayed');
-success('supports async/await');
-```
-
 For debugging, stack traces should point to the correct line:
 
 ```js
@@ -79,7 +71,7 @@ const err = new Error('something went wrong');
 const line = err.stack.split('\n')[1];
 const match = /test.md:(\d+):(\d+)/.exec(line);
 
-assert.equal(match[1], '78'); // line
+assert.equal(match[1], '70'); // line
 assert.equal(match[2], '13'); // column
 
 success('preserves line/column in stack traces');

--- a/test/test.md
+++ b/test/test.md
@@ -45,6 +45,18 @@ fail('should not run this');
 fail('should not run this');
 ```
 
+For debugging, stack traces should point to the correct line:
+
+```js
+const err = new Error('something went wrong');
+const line = err.stack.split('\n')[1];
+const match = /test.md:(\d+):(\d+)/.exec(line);
+
+assert.equal(match[1], '51'); // line
+assert.equal(match[2], '13'); // column
+
+success('preserves line/column in stack traces');
+```
 
 What about requiring other `.md` files?
 
@@ -64,18 +76,6 @@ assert.equal(problems, 99);
 success('imports a `.md` file without specifying the extension');
 ```
 
-For debugging, stack traces should point to the correct line:
-
-```js
-const err = new Error('something went wrong');
-const line = err.stack.split('\n')[1];
-const match = /test.md:(\d+):(\d+)/.exec(line);
-
-assert.equal(match[1], '70'); // line
-assert.equal(match[2], '13'); // column
-
-success('preserves line/column in stack traces');
-```
 
 ## Did it work?
 


### PR DESCRIPTION
Removes the [top-level async function wrapper](https://github.com/Rich-Harris/lit-node/blob/587b680fac3edab69c2400343c7890fcfbd7fe40/compile.js#L24), which causes [a number of problems](https://github.com/Rich-Harris/lit-node/issues/6); consequently, top-level use of the `await` keyword is no longer allowed.